### PR TITLE
Add explain in default

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -91,8 +91,12 @@ class ChiekuiCli:
             print("  - {}".format(cmd))
         print(
             "\n"
-            "Sample:\n\n"
-            "  > python ./cli.py CreateAsset --domain_id japan --precision 0 --asset_name yen\n"
+            "Sample keygen:\n\n"
+            "  > iroha-ya-cli keygen  --account_name mizuki --make_conf yes\n\n"
+            "Sample Tx:\n\n"
+            "  > iroha-ya-cli tx CreateAccount --account_name mizuki --domain_id japan --config config.yml\n"
+            "Sample Query:\n\n"
+            "  > iroha-ya-cli query GetAccount --account_id mizuki@japan --config my_config.yml\n"
         )
 
     def exec_tx(self, cmd, argv):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,7 +61,9 @@ class TestBuildInCommands(unittest.TestCase):
         sys.stdout = sys.__stdout__
         self.assertTrue('{}-mizuki-cli'.format(TARGET) in io.getvalue())
         self.assertTrue('Current support commands' in io.getvalue())
-        self.assertTrue('Sample:' in io.getvalue())
+        self.assertTrue('Sample keygen:' in io.getvalue())
+        self.assertTrue('Sample Tx:' in io.getvalue())
+        self.assertTrue('Sample Query:' in io.getvalue())
 
     def test_config_without_config_data(self):
         sys.stdout = io


### PR DESCRIPTION
Minor change
Add explain by default, when`$ iroha-ya-cli`, it displayed.