### PR TITLE
transaction synchronized with an iroha network

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -137,10 +137,7 @@ class ChiekuiCli:
                 print(res)
             except CliException as e:
                 print(e)
-<<<<<<< HEAD
-=======
                 return -1
->>>>>>> origin/master
         else:
             print("Err")
             return -1

--- a/cli/main.py
+++ b/cli/main.py
@@ -7,7 +7,7 @@ from cli.built_in_commands import BuildInCommand
 from cli.commands import CommandList
 from cli.crypto import KeyPair
 from cli.exception import CliException
-from cli.network import generateTransaction, sendTx, generateQuery, sendQuery
+from cli.network import generateTransaction, sendTx, generateQuery, sendQuery, waitTransaciton
 import cli.file_io as file_io
 from cli.query import QueryList
 
@@ -106,13 +106,22 @@ class ChiekuiCli:
             if not self.context.loaded:
                 print("Config data is not loaded! to send tx require config")
                 return False
-            tx = generateTransaction(self.context.name, [command], self.context.key_pair)
+            tx, tx_hash = generateTransaction(self.context.name, [command], self.context.key_pair)
             if not sendTx(self.context.location, tx):
                 print(
                     "Transaction is not arrived...\n"
                     "Could you ckeck this => {}\n".format(self.context.location)
                 )
                 return False
+            try:
+                waitTransaciton(self.context.location, tx_hash)
+            except Exception as e:
+                print(
+                        "failed to executed the transaction \n"
+                        "error => {}\n".format(e)
+                        )
+                return False
+
         else:
             print("Err")
 
@@ -125,7 +134,7 @@ class ChiekuiCli:
                 res = sendQuery(self.context.location, query)
                 print(res)
             except CliException as e:
-                print(e.message)
+                print(e)
         else:
             print("Err")
 


### PR DESCRIPTION
This pull request makes that, when it sent a transaction to iroha,  iroha-cli become to wait until success or failure the transaction.

In my opinion, after merged this feature, iroha-cli will become more user-friendly. I think that common people do not want to execute a query command many times in order to check whether the transaction is a success.