### PR TITLE
Fix decoding byte-array bug

### DIFF
--- a/iroha_cli/crypto_ed25519.py
+++ b/iroha_cli/crypto_ed25519.py
@@ -15,8 +15,7 @@ def generate_keypair_ed25519():
 
 
 def sign_ed25519(key_pair, message):
-    m = bytearray.fromhex(message.decode('utf-8'))
-    return ed25519.sign(m, key_pair.public_key, key_pair.private_key)
+    return ed25519.sign(message, key_pair.public_key, key_pair.private_key)
 
 
 def verify_ed25519(public_key, signature, message):


### PR DESCRIPTION
Tried to decode a byte array as a UTF-8 string, and failed with UnicodeDecodeError. Fix by removing the decoding.

Signed-off-by: Mitsutaka Takeda <mitsutaka-takeda@altplus.co.jp>